### PR TITLE
Fix config keywordize issue in Serde class

### DIFF
--- a/src/kafka_avro_confluent/serde.clj
+++ b/src/kafka_avro_confluent/serde.clj
@@ -31,14 +31,11 @@
   (s/keys :req-un [::schema-registry-client ::serializer]))
 
 (defn -configure [this m isKey]
-  (let [{serializer-conf      :serializer
-         schema-registry-conf :schema-registry-client
-         :as                  config}
-        (keywordize-keys m)
+  (let [{:keys [serializer schema-registry-client] :as config} (keywordize-keys (into {} m))
         _               (s/assert ::config config)
         serializer-type (if isKey :key :value)
-        avro-schema     (:avro-schema serializer-conf)
-        sr              (sr/->schema-registry-client schema-registry-conf)
+        avro-schema     (:avro-schema serializer)
+        sr              (sr/->schema-registry-client schema-registry-client)
         s               (ser/->avro-serializer sr serializer-type avro-schema)
         d               (des/->avro-deserializer sr)]
     (reset! (.state this)


### PR DESCRIPTION
Hi, 

First, thank you for sharing this project. I tried to implement Serde and struggled with `gen-class`, and then found your project while seeking a clue.  I saw you already implement it elegantly and saved my day!

I tried to use `0.9.1-SNAPSHOT`, but noticed `schema-registry-client` and `serializer` configs are not recognized, and I got an error on deserialization. See https://github.com/parkside-securities/kafka-avro-confluent/issues/1 

Please consider merging this so we can keep using your project rather than our fork. I confirmed serialization by Kafka producer, and deserialization by Serde, but haven't tested other permutations yet. 

Cheers, 