### PR TITLE
Add convert-logical-types-flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ If you need to deserialise to the underlying primitive types you will need to di
 at the point of creating your deserialiser i.e.
 
 ```clojure
-(binding [abracad.avro.conversion/*use-logical-types* false]
-  (des/->avro-deserializer schema-registry))
+(des/->avro-deserializer schema-registry :convert-logical-types? false)
 ```
 
 ## Usage

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/kafka-avro-confluent "2.0.1-1"
+(defproject ovotech/kafka-avro-confluent "2.0.1-2"
 
   :description "An Avro Kafka De/Serializer lib that works with Confluent's Schema Registry"
 

--- a/test/kafka_avro_confluent/core_test.clj
+++ b/test/kafka_avro_confluent/core_test.clj
@@ -14,7 +14,7 @@
                    :fields [{:name "fooId"
                              :type "string"}
                             {:name "fooDate"
-                             :type {:type :int
+                             :type {:type        :int
                                     :logicalType :date}}]})
 
 (def dummy-data {:fooId "42" :fooDate (LocalDate/of 2018 11 23)})
@@ -29,7 +29,7 @@
   (testing "Can round-trip"
     (let [serializer   (sut-ser/->avro-serializer schema-registry dummy-schema)
           deserializer (sut-des/->avro-deserializer schema-registry)
-          topic (dummy-topic)]
+          topic        (dummy-topic)]
 
       (is (= dummy-data
              (->> dummy-data
@@ -77,3 +77,14 @@
                  (sut-ser/->avro-serializer schema-registry
                                             :nefarious-serializer-type
                                             dummy-schema)))))
+
+(deftest can-stop-auto-conversion-of-logical-types
+  (testing "Can round-trip"
+    (let [serializer   (sut-ser/->avro-serializer schema-registry dummy-schema)
+          deserializer (sut-des/->avro-deserializer schema-registry :convert-logical-types? false)
+          topic        (dummy-topic)
+          {:keys [fooDate]} (->> dummy-data
+                                 (.serialize serializer topic)
+                                 (.deserialize deserializer topic))]
+
+      (is (= 17858 fooDate)))))


### PR DESCRIPTION
The existing use of the `abracad.avro.conversion/*use-logical-types*` dynamic flag just didn't work for switching off logical type conversion during deserialization because the binding was being applied during construction of the deserializer rather than at the point of deserialization.

This new flag is passed directly into the deserialization function and enforces the binding of the above dynamic var at the point of deserialization.