### PR TITLE
[rfc] Serdeconfs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/kafka-avro-confluent "2.1.0-2"
+(defproject ovotech/kafka-avro-confluent "2.1.0-3"
 
   :description "An Avro Kafka De/Serializer lib that works with Confluent's Schema Registry"
 

--- a/src/kafka_avro_confluent/deserializers.clj
+++ b/src/kafka_avro_confluent/deserializers.clj
@@ -40,6 +40,8 @@
    See https://github.com/damballa/abracad"
   ;; FIXME https://github.com/miner/eastwood#wrong-tag---an-incorrect-type-tag
   ^kafka_avro_confluent.deserializers.AvroDeserializer
-  [schema-registry & {:keys [convert-logical-types?]
-                      :or   {convert-logical-types? true}}]
-  (AvroDeserializer. schema-registry convert-logical-types?))
+  [schema-registry-client-or-config
+   & {:keys [convert-logical-types?]
+      :or   {convert-logical-types? true}}]
+  (AvroDeserializer. (registry/->schema-registry-client schema-registry-client-or-config)
+                     convert-logical-types?))

--- a/src/kafka_avro_confluent/serdes.clj
+++ b/src/kafka_avro_confluent/serdes.clj
@@ -1,0 +1,11 @@
+(ns kafka-avro-confluent.serdes
+  (:require [kafka-avro-confluent.deserializers :as kac.des]
+            [kafka-avro-confluent.serializers :as kac.ser])
+  (:import org.apache.kafka.common.serialization.Serdes))
+
+(defn ->avro-serde
+  ([schema-registry schema]
+   (->avro-serde schema-registry :value schema))
+  ([schema-registry serializer-type schema]
+   (Serdes/serdeFrom (kac.ser/->avro-serializer schema-registry serializer-type schema)
+                     (kac.des/->avro-deserializer schema-registry))))

--- a/src/kafka_avro_confluent/serdes.clj
+++ b/src/kafka_avro_confluent/serdes.clj
@@ -4,8 +4,8 @@
   (:import org.apache.kafka.common.serialization.Serdes))
 
 (defn ->avro-serde
-  ([schema-registry schema]
-   (->avro-serde schema-registry :value schema))
-  ([schema-registry serializer-type schema]
-   (Serdes/serdeFrom (kac.ser/->avro-serializer schema-registry serializer-type schema)
-                     (kac.des/->avro-deserializer schema-registry))))
+  ([schema-registry-client-or-config schema]
+   (->avro-serde schema-registry-client-or-config :value schema))
+  ([schema-registry-client-or-config serializer-type schema]
+   (Serdes/serdeFrom (kac.ser/->avro-serializer schema-registry-client-or-config serializer-type schema)
+                     (kac.des/->avro-deserializer schema-registry-client-or-config))))

--- a/src/kafka_avro_confluent/serializers.clj
+++ b/src/kafka_avro_confluent/serializers.clj
@@ -50,8 +50,10 @@
    See http://docs.confluent.io/current/schema-registry/docs
    See https://github.com/damballa/abracad"
   ;; FIXME https://github.com/miner/eastwood#wrong-tag---an-incorrect-type-tag
-  (^kafka_avro_confluent.serializers.AvroSerializer [schema-registry schema]
-   (AvroSerializer. schema-registry :value schema))
-  (^kafka_avro_confluent.serializers.AvroSerializer [schema-registry serializer-type schema]
+  (^kafka_avro_confluent.serializers.AvroSerializer [schema-registry-client-or-config schema]
+   (->avro-serializer schema-registry-client-or-config :value schema))
+  (^kafka_avro_confluent.serializers.AvroSerializer [schema-registry-client-or-config serializer-type schema]
    {:pre [(#{:key :value} serializer-type)]}
-   (AvroSerializer. schema-registry serializer-type schema)))
+   (AvroSerializer. (registry/->schema-registry-client schema-registry-client-or-config)
+                    serializer-type
+                    schema)))

--- a/src/kafka_avro_confluent/v2/serde.clj
+++ b/src/kafka_avro_confluent/v2/serde.clj
@@ -1,0 +1,10 @@
+(ns kafka-avro-confluent.v2.serde
+  (:require [kafka-avro-confluent.v2.deserializer :as kac.des]
+            [kafka-avro-confluent.v2.serializer :as kac.ser])
+  (:import org.apache.kafka.common.serialization.Serdes))
+
+(defn ->avro-serde
+  [config & {:keys [key?]
+             :or   {key? false}}]
+  (Serdes/serdeFrom (kac.ser/->avro-serializer config :key? key?)
+                    (kac.des/->avro-deserializer config)))

--- a/test/kafka_avro_confluent/core_test.clj
+++ b/test/kafka_avro_confluent/core_test.clj
@@ -23,8 +23,10 @@
 (defn dummy-topic []
   (str (UUID/randomUUID)))
 
+(def schema-registry-config
+  {:base-url "http://localhost:8081"})
 (def schema-registry
-  (sut-reg/->schema-registry-client {:base-url "http://localhost:8081"}))
+  (sut-reg/->schema-registry-client schema-registry-config))
 
 (deftest avro-serde
   (testing "Can round-trip"
@@ -46,6 +48,16 @@
       (testing "uses :value as default `serializer-type`"
         (is (sut-reg/get-latest-schema-by-subject schema-registry
                                                   (str topic "-value")))))))
+
+(deftest avro-serde-with-config-constructor
+  (testing "Can round-trip"
+    (let [serializer   (sut-ser/->avro-serializer schema-registry-config dummy-schema)
+          deserializer (sut-des/->avro-deserializer schema-registry-config)
+          topic        (dummy-topic)]
+      (is (= dummy-data
+             (->> dummy-data
+                  (.serialize serializer topic)
+                  (.deserialize deserializer topic)))))))
 
 (deftest avro-serde-with-explicit-serializer-type
 

--- a/test/kafka_avro_confluent/core_test.clj
+++ b/test/kafka_avro_confluent/core_test.clj
@@ -36,6 +36,12 @@
                   (.serialize serializer topic)
                   (.deserialize deserializer topic))))
 
+      (testing "works with nil headers"
+        (is (= dummy-data
+               (->> dummy-data
+                    (.serialize serializer topic nil)
+                    (.deserialize deserializer topic nil)))))
+
       (testing "uses :value as default `serializer-type`"
         (is (sut-reg/get-latest-schema-by-subject schema-registry
                                                   (str topic "-value")))))))

--- a/test/kafka_avro_confluent/v2/core_test.clj
+++ b/test/kafka_avro_confluent/v2/core_test.clj
@@ -37,6 +37,11 @@
              (->> {:value dummy-data :schema dummy-schema}
                   (.serialize serializer topic)
                   (.deserialize deserializer topic))))
+      (testing "works with nil headers"
+        (is (= dummy-data
+               (->> {:value dummy-data :schema dummy-schema}
+                    (.serialize serializer topic nil)
+                    (.deserialize deserializer topic nil)))))
       (testing "uses :value as default `serializer-type`"
         (is (sut-reg/get-latest-schema-by-subject schema-registry-client
                                                   (str topic "-value")))))))

--- a/test/kafka_avro_confluent/v2/core_test.clj
+++ b/test/kafka_avro_confluent/v2/core_test.clj
@@ -4,6 +4,7 @@
             [clojure.test :refer :all]
             [kafka-avro-confluent.v2.deserializer :as sut-des]
             [kafka-avro-confluent.v2.schema-registry-client :as sut-reg]
+            [kafka-avro-confluent.v2.serde :as sut-serde]
             [kafka-avro-confluent.v2.serializer :as sut-ser]
             [zookareg.core :as zkr])
   (:import java.util.UUID))
@@ -65,6 +66,20 @@
           schema       (avro/parse-schema dummy-schema)]
       (is (= dummy-data
              (->> {:value dummy-data :schema schema}
+                  (.serialize serializer topic)
+                  (.deserialize deserializer topic))))
+      (testing "uses :value as default `serializer-type`"
+        (is (sut-reg/get-latest-schema-by-subject schema-registry-client
+                                                  (str topic "-value")))))))
+
+(deftest avro-Serde
+  (testing "Can round-trip"
+    (let [serde        (sut-serde/->avro-serde config)
+          serializer   (.serializer serde)
+          deserializer (.deserializer serde)
+          topic        (dummy-topic)]
+      (is (= dummy-data
+             (->> {:value dummy-data :schema dummy-schema}
                   (.serialize serializer topic)
                   (.deserialize deserializer topic))))
       (testing "uses :value as default `serializer-type`"


### PR DESCRIPTION
- add utility `org.apache.kafka.common.serialization.Serdes` constructors to both v1 and v2
- make v1 accept a  schema-registry config as well as a schema-registry client
- test the headers functionality added in previous commits

This means you can create a serde with:
```clojure
(def serde (kac.serde/->avro-serde {:base-url "http://localhost:8081"}
                                   {:type "long"
                                    :logicalType "timestamp-millis"}))
```
rather than:
```clojure
(def conf {:base-url "http://localhost:8081"})
(def sr (kac.registry/->schema-registry-client conf))
(def schema {:type "long"
           :logicalType "timestamp-millis"}
(def ser (kac.serializer/->avro-serializer sr schema))
(def des (kac.deserializer/->avro-deserializer des))
(def serde (org.apache.kafka.common.serialization.Serdes/serdeFrom ser des))
```
which was kind of driving me nuts

note that this is a backward compatible change (i.e. the second way of doing it will still work)
