### PR TITLE
Upgrade abracad

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
 
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/core.memoize "0.7.1"]
-                 [ovotech/abracad "0.4.15"]
+                 [ovotech/abracad "0.4.16"]
                  [cheshire "5.8.1"]
 
                  [clj-http "3.9.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/kafka-avro-confluent "2.1.0-4"
+(defproject ovotech/kafka-avro-confluent "2.1.0-5"
 
   :description "An Avro Kafka De/Serializer lib that works with Confluent's Schema Registry"
 


### PR DESCRIPTION
Upgrades abracad to this version -> https://github.com/ovotech/abracad/pull/3

In order to get updated dependencies to fix NVD failures