### PR TITLE
Only AOT in dev profile to avoid namespaces from libs like cheshire being hardbaked into the library and thus confusing the classloader for downstream libraries.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/kafka-avro-confluent "2.1.0-5"
+(defproject ovotech/kafka-avro-confluent "2.1.0-6"
 
   :description "An Avro Kafka De/Serializer lib that works with Confluent's Schema Registry"
 
@@ -18,18 +18,17 @@
                   :exclusions [org.scala-lang/scala-library]]
                  [org.clojure/tools.logging "0.4.1"]]
 
-  :aot [kafka-avro-confluent.serializers
-        kafka-avro-confluent.deserializers
-        kafka-avro-confluent.v2.serializer
-        kafka-avro-confluent.v2.deserializer]
-
   :repositories {"confluent" "https://packages.confluent.io/maven"}
 
   :profiles {:dev {:dependencies   [[vise890/zookareg "2.1.0-1"]
                                     [ch.qos.logback/logback-classic "1.2.3"]
                                     [ch.qos.logback/logback-core "1.2.3"]]
-                   :resource-paths ["dev/resources" "test/resources"]}
-             :ci {:deploy-repositories [["clojars" {:url           "https://clojars.org/repo"
-                                                    :username      :env ;; LEIN_USERNAME
-                                                    :password      :env ;; LEIN_PASSWORD
-                                                    :sign-releases false}]]}})
+                   :resource-paths ["dev/resources" "test/resources"]
+                   :aot            [kafka-avro-confluent.serializers
+                                    kafka-avro-confluent.deserializers
+                                    kafka-avro-confluent.v2.serializer
+                                    kafka-avro-confluent.v2.deserializer]}
+             :ci  {:deploy-repositories [["clojars" {:url           "https://clojars.org/repo"
+                                                     :username      :env ;; LEIN_USERNAME
+                                                     :password      :env ;; LEIN_PASSWORD
+                                                     :sign-releases false}]]}})


### PR DESCRIPTION
***What***: Moves the AOT'd namespaces to the `:dev` profile.
***Why***: We've been seeing some very strange behaviour in a downstream service consuming this library. Specifically our service was struggling to find `cheshire.core/parse-stream-strict` despite the fact that we included cheshire `5.10.0` as a dependency. In the end, I tracked it down to these AOT'd namespaces - I *think* what's happening is during compilation of these namespaces the namespaces that they `require` are being hardbaked into those compiled classes and therefore confusing the classloader in our downstream service when it tries to find the `clojure.core` namespace. As the version of cheshire (`5.8.1`) used in kafka-avro-confluent pre-dates the addition `parse-stream-strict` function, that function can't be found.

As a side-note, we're not actually using the `parse-stream-strict` function explicitly - it's used by clj-http `3.10.x`.